### PR TITLE
Expand EmitterKeyType and Consume in KeygenRequest.ToJson

### DIFF
--- a/Emitter.Sample/Program.cs
+++ b/Emitter.Sample/Program.cs
@@ -16,7 +16,7 @@ namespace Emitter.Sample
             using (var emitter = Connection.Establish())
             {
                 // Generate a read-write key for our channel
-                emitter.GenerateKey("<secret key>", "chat", Messages.EmitterKeyType.ReadWrite, (keygen) =>
+                emitter.GenerateKey("<secret key>", "chat", Messages.SecurityAccess.ReadWrite, (keygen) =>
                 {
                     Console.WriteLine("Generated Key: " + keygen.Key);
                 });

--- a/Emitter/Emitter.cs
+++ b/Emitter/Emitter.cs
@@ -379,10 +379,10 @@ namespace Emitter
         /// </summary>
         /// <param name="secretKey">The secret key for this request.</param>
         /// <param name="channel">The target channel for the requested key.</param>
-        /// <param name="keyType">The type of the requested key.</param>
-        public void GenerateKey(string secretKey, string channel, EmitterKeyType keyType, KeygenHandler handler)
+        /// <param name="securityAccess">The security access of the requested key.</param>
+        public void GenerateKey(string secretKey, string channel, SecurityAccess securityAccess, KeygenHandler handler)
         {
-            this.GenerateKey(secretKey, channel, keyType, 0, handler);
+            this.GenerateKey(secretKey, channel, securityAccess, 0, handler);
         }
 
         /// <summary>
@@ -390,15 +390,15 @@ namespace Emitter
         /// </summary>
         /// <param name="secretKey">The secret key for this request.</param>
         /// <param name="channel">The target channel for the requested key.</param>
-        /// <param name="keyType">The type of the requested key.</param>
+        /// <param name="securityAccess">The security access of the requested key.</param>
         /// <param name="ttl">The number of seconds for which this key will be usable.</param>
-        public void GenerateKey(string secretKey, string channel, EmitterKeyType keyType, int ttl, KeygenHandler handler)
+        public void GenerateKey(string secretKey, string channel, SecurityAccess securityAccess, int ttl, KeygenHandler handler)
         {
             // Prepare the request
             var request = new KeygenRequest();
             request.Key = secretKey;
             request.Channel = channel;
-            request.Type = keyType;
+            request.Type = securityAccess;
             request.Ttl = ttl;
 
             // Register the handler

--- a/Emitter/Messages/KeygenRequest.cs
+++ b/Emitter/Messages/KeygenRequest.cs
@@ -37,7 +37,7 @@ namespace Emitter.Messages
         /// <summary>
         /// Gets or sets the type of the requested key.
         /// </summary>
-        public EmitterKeyType Type;
+        public SecurityAccess Type;
 
         /// <summary>
         /// Gets or sets the number of seconds for which this key will be usable.
@@ -51,15 +51,15 @@ namespace Emitter.Messages
         public string ToJson()
         {
             var keyType = "";
-            if ((this.Type & EmitterKeyType.Read) != 0)
+            if ((this.Type & SecurityAccess.Read) != 0)
                 keyType += "r";
-            if ((this.Type & EmitterKeyType.Write) != 0)
+            if ((this.Type & SecurityAccess.Write) != 0)
                 keyType += "w";
-            if ((this.Type & EmitterKeyType.Store) != 0)
+            if ((this.Type & SecurityAccess.Store) != 0)
                 keyType += "s";
-            if ((this.Type & EmitterKeyType.Load) != 0)
+            if ((this.Type & SecurityAccess.Load) != 0)
                 keyType += "l";
-            if ((this.Type & EmitterKeyType.Presence) != 0)
+            if ((this.Type & SecurityAccess.Presence) != 0)
                 keyType += "p";
 
             return JsonSerializer.SerializeObject(new Hashtable
@@ -75,8 +75,16 @@ namespace Emitter.Messages
     /// <summary>
     /// Represents the key type.
     /// </summary>
-    [Flags]
+    [Obsolete("Use SecurityAccess enum instead")]
     public enum EmitterKeyType : uint
+    {
+    }
+
+    /// <summary>
+    /// Represents the security access particular to a given key.
+    /// </summary>
+    [Flags]
+    public enum SecurityAccess : uint
     {
         /// <summary>
         /// Key has no privileges.
@@ -99,7 +107,7 @@ namespace Emitter.Messages
         Store = 1 << 3,
 
         /// <summary>
-        /// Key should be allowed to write to read the message history of the target channel.
+        /// Key should be allowed to read the message history of the target channel.
         /// </summary>
         Load = 1 << 4,
 
@@ -116,19 +124,7 @@ namespace Emitter.Messages
         /// <summary>
         /// Key should be allowed to read and write the message history.
         /// </summary>
-        StoreLoad = Store | Load,
+        StoreLoad = Store | Load
 
-        /// <summary>
-        /// Requests the key to be a read-only key.
-        /// </summary>
-        [Obsolete("Use EmitterKeyType.Read instead")]
-        ReadOnly  = Read,
-
-        /// <summary>
-        /// Requests the key to be a write-only key.
-        /// </summary>
-        [Obsolete("Use EmitterKeyType.Write instead")]
-        WriteOnly = Write,
-        
     }
 }

--- a/Emitter/Messages/KeygenRequest.cs
+++ b/Emitter/Messages/KeygenRequest.cs
@@ -50,43 +50,85 @@ namespace Emitter.Messages
         /// <returns></returns>
         public string ToJson()
         {
-            var keyType = "r";
-            switch(this.Type)
+            var keyType = "";
+            if ((this.Type & EmitterKeyType.Read) != 0)
+                keyType += "r";
+            if ((this.Type & EmitterKeyType.Write) != 0)
+                keyType += "w";
+            if ((this.Type & EmitterKeyType.Store) != 0)
+                keyType += "s";
+            if ((this.Type & EmitterKeyType.Load) != 0)
+                keyType += "l";
+            if ((this.Type & EmitterKeyType.Presence) != 0)
+                keyType += "p";
+
+            return JsonSerializer.SerializeObject(new Hashtable
             {
-                case EmitterKeyType.WriteOnly: keyType = "w"; break;
-                case EmitterKeyType.ReadWrite: keyType = "rw"; break;
-                case EmitterKeyType.ReadOnly:
-                default: keyType = "r"; break;
-            }
-
-            var map = new Hashtable();
-            map.Add("key", this.Key);
-            map.Add("channel", this.Channel);
-            map.Add("type", keyType);
-            map.Add("ttl", this.Ttl);
-
-            return JsonSerializer.SerializeObject(map);
+                {"key", this.Key},
+                {"channel", this.Channel},
+                {"type", keyType},
+                {"ttl", this.Ttl}
+            });
         }
     }
 
     /// <summary>
     /// Represents the key type.
     /// </summary>
-    public enum EmitterKeyType
+    [Flags]
+    public enum EmitterKeyType : uint
     {
+        /// <summary>
+        /// Key has no privileges.
+        /// </summary>
+        None = 0,
+        
+        /// <summary>
+        /// Key should be allowed to subscribe to the target channel.
+        /// </summary>
+        Read = 1 << 1,
+
+        /// <summary>
+        /// Key should be allowed to publish to the target channel.
+        /// </summary>
+        Write = 1 << 2,
+
+        /// <summary>
+        /// Key should be allowed to write to the message history of the target channel.
+        /// </summary>
+        Store = 1 << 3,
+
+        /// <summary>
+        /// Key should be allowed to write to read the message history of the target channel.
+        /// </summary>
+        Load = 1 << 4,
+
+        /// <summary>
+        /// Key should be allowed to query the presence on the target channel.
+        /// </summary>
+        Presence = 1 << 5,
+
+        /// <summary>
+        /// Key should be allowed to read and write to the target channel.
+        /// </summary>
+        ReadWrite = Read | Write,
+
+        /// <summary>
+        /// Key should be allowed to read and write the message history.
+        /// </summary>
+        StoreLoad = Store | Load,
+
         /// <summary>
         /// Requests the key to be a read-only key.
         /// </summary>
-        ReadOnly  = 0,
+        [Obsolete("Use EmitterKeyType.Read instead")]
+        ReadOnly  = Read,
 
         /// <summary>
         /// Requests the key to be a write-only key.
         /// </summary>
-        WriteOnly = 1,
-
-        /// <summary>
-        /// Requests the key to be a read/write key.
-        /// </summary>
-        ReadWrite = 2
+        [Obsolete("Use EmitterKeyType.Write instead")]
+        WriteOnly = Write,
+        
     }
 }


### PR DESCRIPTION
No breaking changes were made, though several enum values were flagged as Obsolete. I copied over the full values and documentation from the Runtime for SecurityAccess.

Side question... should EmitterKeyType be named SecurityAccess?